### PR TITLE
fix(wake-up): rename 'mx encode-commit' to 'mx commit --encode-only'

### DIFF
--- a/.github/workflows/wake-up.yml
+++ b/.github/workflows/wake-up.yml
@@ -212,7 +212,7 @@ jobs:
 
           # Encode with mx (random algos + dictionaries)
           # Output format: line 1 = title, line 3 = body, line 5 = footer
-          ENCODED=$(mx encode-commit --title "$VERSION" --body "$MESSAGE")
+          ENCODED=$(mx commit --encode-only --title "$VERSION" --body "$MESSAGE")
           TITLE=$(echo "$ENCODED" | sed -n '1p')
           BODY=$(echo "$ENCODED" | sed -n '3p')
           FOOTER=$(echo "$ENCODED" | sed -n '5p')


### PR DESCRIPTION
## Summary

One-line fix on `.github/workflows/wake-up.yml:215`. The `Bump Version` job calls a subcommand that no longer exists.

**Before:**
```bash
ENCODED=$(mx encode-commit --title "$VERSION" --body "$MESSAGE")
```

**After:**
```bash
ENCODED=$(mx commit --encode-only --title "$VERSION" --body "$MESSAGE")
```

The `sed -n '1p/3p/5p'` parser on lines 216-218 is unchanged — output format is byte-identical.

## Context

- `mx encode-commit` was a hidden deprecated shim introduced in coryzibell/mx#49 (2025-12-01). Because it carried `hide = true`, it never appeared in `mx --help`, so downstream dependencies on it were invisible.
- The shim was removed in mx commit `f53857f` on 2026-04-01 ("Clean up vestigial commands and references", closes coryzibell/mx#154). The removal commit body literally reads: *"mx commit --encode-only is the replacement."*
- This workflow was never updated — not when the shim landed, not when it was removed.
- The breakage surfaced today (2026-04-09) when the `Bump Version` job failed on mx's main-branch CI run [24187799632](https://github.com/coryzibell/mx/actions/runs/24187799632/job/70606213633) after coryzibell/mx#200 merged.

## Verification

Snoopworth confirmed output format is byte-identical against:
- `commit::encode_commit_message` at `mx/src/main.rs:1576-1586`
- `EncodedCommit::message()` at `mx/src/commit.rs:256-258`

Both invocations call the same underlying code path. Specifically:
- **stdout:** identical byte-for-byte
- **exit code:** unchanged
- **stderr:** slightly cleaner (no deprecation warning)
- **parser impact:** zero — `sed -n '1p/3p/5p'` still reads title/body/footer off lines 1/3/5

## Blast Radius

`wake-up.yml` is a reusable workflow consumed by **all coryzibell Rust repos** pinned at `@main`. mx's own `.github/workflows/wake-up.yml` delegates here at line 16. This one-line fix unblocks every downstream consumer simultaneously the moment it merges.

Once merged, a rerun of mx run [24187799632](https://github.com/coryzibell/mx/actions/runs/24187799632) will pick up the fix automatically via the `@main` pin — no mx-side change needed.

## Test plan

- [ ] Verdictia reviews the one-line diff
- [ ] Merge to nebuchadnezzar main
- [ ] Rerun mx `Bump Version` job 70606213633 and confirm it passes
- [ ] Spot-check one or two other downstream consumers on their next scheduled wake-up