### PR TITLE
fix(install-deps): drop choco openssl, use runner-bundled path

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -3,7 +3,10 @@ description: 'Cross-platform system dependency installation'
 
 inputs:
   needs-openssl:
-    description: 'Require OpenSSL'
+    description: >-
+      Require OpenSSL system libraries. For Rust consumers, prefer rustls over
+      native-tls/openssl-sys to avoid C binding dependencies entirely — set this
+      to false and configure your crate features accordingly.
     required: false
     default: 'false'
   extra-apt-packages:
@@ -63,18 +66,25 @@ runs:
         echo "PKG_CONFIG_PATH=$(brew --prefix openssl@3)/lib/pkgconfig" >> $GITHUB_ENV
 
     - name: Install dependencies (Windows)
-      if: runner.os == 'Windows'
+      if: runner.os == 'Windows' && inputs.extra-choco-packages != ''
       shell: pwsh
       run: |
-        $packages = @()
-        if ("${{ inputs.needs-openssl }}" -eq "true") {
-          $packages += "openssl"
-        }
-        $extra = "${{ inputs.extra-choco-packages }}"
-        if ($extra) {
-          $packages += $extra -split ' '
-        }
-        if ($packages.Count -gt 0) {
-          Write-Host "Installing: $($packages -join ', ')"
-          choco install $packages -y
+        $packages = "${{ inputs.extra-choco-packages }}" -split ' '
+        Write-Host "Installing: $($packages -join ', ')"
+        choco install $packages -y
+
+    - name: Set OpenSSL environment (Windows)
+      if: runner.os == 'Windows' && inputs.needs-openssl == 'true'
+      shell: pwsh
+      run: |
+        # The runner image (windows-2025) bundles OpenSSL at this path.
+        # We set OPENSSL_DIR so openssl-sys can find headers and libraries.
+        # No choco/slproweb download needed.
+        $opensslDir = "C:\Program Files\OpenSSL"
+        if (Test-Path $opensslDir) {
+          Write-Host "Using runner-bundled OpenSSL at $opensslDir"
+          echo "OPENSSL_DIR=$opensslDir" >> $env:GITHUB_ENV
+        } else {
+          Write-Error "OpenSSL not found at $opensslDir — runner image may have changed. Consider switching to rustls."
+          exit 1
         }

--- a/.github/workflows/deja-vu.yml
+++ b/.github/workflows/deja-vu.yml
@@ -1,0 +1,71 @@
+# deja vu.
+# self-test for composite actions - a glitch in the matrix means something changed.
+name: deja vu.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test-install-deps:
+    name: install-deps (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # --- Default path (needs-openssl: false) ---
+
+      - name: Run install-deps (default)
+        uses: ./.github/actions/install-deps
+
+      # --- OpenSSL path (needs-openssl: true) ---
+
+      - name: Run install-deps (needs-openssl)
+        uses: ./.github/actions/install-deps
+        with:
+          needs-openssl: 'true'
+
+      - name: Verify OpenSSL (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          VERSION=$(pkg-config --modversion openssl)
+          echo "pkg-config openssl version: $VERSION"
+          if [ -z "$VERSION" ]; then
+            echo "::error::pkg-config could not resolve openssl"
+            exit 1
+          fi
+
+      - name: Verify OpenSSL (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          echo "OPENSSL_DIR=$OPENSSL_DIR"
+          if [ -z "$OPENSSL_DIR" ]; then
+            echo "::error::OPENSSL_DIR is not set"
+            exit 1
+          fi
+          if [ ! -d "$OPENSSL_DIR" ]; then
+            echo "::error::OPENSSL_DIR does not exist: $OPENSSL_DIR"
+            exit 1
+          fi
+
+      - name: Verify OpenSSL (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          echo "OPENSSL_DIR=$OPENSSL_DIR"
+          if [ -z "$OPENSSL_DIR" ]; then
+            echo "::error::OPENSSL_DIR is not set"
+            exit 1
+          fi
+          if [ ! -d "$OPENSSL_DIR" ]; then
+            echo "::error::OPENSSL_DIR does not exist: $OPENSSL_DIR"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- **Drop `choco install openssl`** — removes the flaky slproweb.com CDN dependency that caused 404s and CI failures on Windows
- **Use runner-bundled OpenSSL** — `windows-2025`/`windows-latest` ships OpenSSL 3.6.1 at `C:\Program Files\OpenSSL`. We now set `OPENSSL_DIR` via `$GITHUB_ENV` (mirroring the macOS pattern) so `openssl-sys` can find it
- **Add rustls guidance** — the `needs-openssl` input description now notes that Rust consumers should prefer rustls over native-tls/openssl-sys to avoid C binding dependencies entirely
- **Fail loud** — if the runner-bundled path is missing (future image change), the step errors with a clear message suggesting rustls as the escape hatch

No current consumers pass `needs-openssl: true` (mx and base-d both default to false), but the action advertises the capability and it should work.

Closes #11

## Test plan

- [ ] CI passes on this PR (the matrix runs on linux/mac/windows)
- [ ] Verify Windows steps don't attempt choco openssl install
- [ ] Verify `needs-openssl: false` (default) skips the new OpenSSL env step entirely